### PR TITLE
(Temporary?) workaround for style inclusion in D1.3 report

### DIFF
--- a/Proposal/preamble.tex
+++ b/Proposal/preamble.tex
@@ -1,5 +1,5 @@
 \usepackage{lscape} % for landscape
-\usepackage{comment}
+\usepackage{comments}
 % %\usepackage[final]{comments}
 \usepackage{verbatim}
 \usepackage{listings}

--- a/WP1/D1.3/comments.sty
+++ b/WP1/D1.3/comments.sty
@@ -1,0 +1,52 @@
+% $id$
+% KH: created comments style file to allow alternative versions of a document.
+% KH: added draft environment
+
+% \newcommand{\red}[1]{#1}
+
+%\usepackage[usenames]{color}
+\definecolor{BrickRed}{cmyk}{0, .89, .5, 0} 
+\definecolor{Blue}{cmyk}{.8, .3, .2, 0} 
+\definecolor{Green}{cmyk}{1, 0.2, 1, 0} 
+\definecolor{Black}{cmyk}{1, 1, 1, 0} 
+\newcommand{\red}{\color{BrickRed}}
+\newcommand{\blue}{\color{Blue}}
+\newcommand{\green}{\color{Green}}
+\newcommand{\black}{\color{Black}}
+
+\newcommand{\eucommentary}[1]{{\red\(\spadesuit\){\textbf{EC Commentary}: \emph{#1}}\(\spadesuit\)}}
+\newcommand{\euevaluation}[2]{{\red\(\spadesuit\){\textbf{Evaluation Criteria ({#1})}: \emph{#2}}\(\spadesuit\)}}
+
+%\newcommand{\comment}[2]{{\blue\(\spadesuit\){\bf #1: }{\textit{#2}}\(\spadesuit\)}}
+\newcommand{\draftpage}{\newpage}
+
+\newcommand{\FIXME}[1]{[\textbf{FIXME}: #1]}
+
+\newcommand{\COMMENT}[1]{{\green\(\spadesuit\){\emph{#1}}\(\spadesuit\)}}
+\newcommand{\TODO}[1]{{\green\(\spadesuit\){\textbf{TO DO}: \emph{#1}}\(\spadesuit\)}}
+
+\newcommand{\TOWRITE}[2]{{\green\(\spadesuit\){#1 [\textbf{WRITE HERE}: #2]}\(\spadesuit\)}}
+
+\newenvironment{draft}{\red}{}
+
+\newcommand{\nocomments}{
+\let\draft=\comment
+\let\enddraft=\endcomment
+\renewcommand{\eucommentary}[1]{}
+\renewcommand{\euevaluation}[2]{}
+%\renewcommand{\comment}[2]{}
+\renewcommand{\draftpage}{}
+\renewcommand{\FIXME}[1]{}
+\renewcommand{\TODO}[1]{}
+\renewcommand{\COMMENT}[1]{}
+\renewcommand{\TOWRITE}[2]{}%tinyitquote
+}
+
+\DeclareOption{final}{\nocomments}
+\DeclareOption{submit}{\nocomments}
+\DeclareOption{draft}{}
+\ProcessOptions*
+
+%  LocalWords:  newcommand usepackage usenames definecolor cmyk eucommentary spadesuit
+%  LocalWords:  textbf emph spadesuit euevaluation textit draftpage newpage TOWRITE
+%  LocalWords:  newenvironment nocomments renewcommand tinyitquote


### PR DESCRIPTION
I misled @bpilorget by suggesting the change that this reverts.

The confusion was that there is a standard package called just 'comment' https://www.ctan.org/tex-archive/macros/latex/contrib/comment?lang=en but that in older versions included a 'comments.sty' which I thought this could be referring to.  But intead it refers to a style file in the Proposal/ directory.

In the report for D1.2 @nthiery just copied the style file into that directory which happens to work (if the report directory happens to be your working directory).  But other than that if some style is going to be shared between documents a better way is needed (such as a makefile that includes it in the search path).
