### PR TITLE
Suggested changes to WP7: move JOOMMF evaluation into WP2 task

### DIFF
--- a/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
+++ b/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
@@ -9,7 +9,7 @@
   PSRM=9,
   SARM=18,
   USORM=1, %16 in total
-  XFELRM=21, % moved 6PM from WP7
+  XFELRM=21, % moved 6PM from WP7 (15 + 6 = 21)
   USHRM=22,
   USRM=30,
   UVRM=2,

--- a/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
+++ b/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
@@ -9,7 +9,7 @@
   PSRM=9,
   SARM=18,
   USORM=1, %16 in total
-  XFELRM=15,
+  XFELRM=21, % moved 6PM from WP7
   USHRM=22,
   USRM=30,
   UVRM=2,

--- a/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
+++ b/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
@@ -326,67 +326,71 @@ id=dissemination-of-oommf-nb-workshops,lead=XFEL,PM=6,partners={USO},wphases=18-
 
   % 3 months person time, 2 months investigator time
 
-We will run a series of workshops
-(\delivref{dissem}{oommfnb-vre-deliver}) during the evenings of 4 major
-international meetings on magnetism research\footnote{Anticipated most
-  significant international meetings in the appropriate time frame are
-  61st Conference on Magnetism and Magnetic Materials (MMM2016), October
-  31-November 4, 2016, New Orleans, Louisiana; 62nd Conference on
-  Magnetism and Magnetic Materials (MMM 2017), November 6-10, 2017, Pittsburgh,
-  Pennsylvania; 21st International Conference on Magnetism (ICM 2018),
-  July 16–20, 2018, San Francisco, California; 14th Joint MMM-Intermag
-  Conference (MMM2019), January 14-18, 2019, Washington, DC). Each of those
-  meetings is one week long, and serves as a focal point of networking
-  for the european and international research community. Other training events have been held in the
-past at these conferences and were well attended.} to
-disseminate the micromagnetic virtual research environment
-(Sect. \ref{sec:introduction-micromagnetic-vre-demonstrator} and
-\localtaskref{dissemination-of-oommf-nb-virtual-environment}) in the
-micromagnetic community. Each conference
-attracts around 1500 participants, and we expect at least 30 for our
-workshops at every event. Depending on demand, multiple workshops
-will be given per conference.
+  We will run a series of workshops
+  (\delivref{dissem}{oommfnb-vre-deliver}) during the evenings of 4
+  major international meetings on magnetism
+  research\footnote{Anticipated most significant international
+    meetings in the appropriate time frame are 61st Conference on
+    Magnetism and Magnetic Materials (MMM2016), October 31-November 4,
+    2016, New Orleans, Louisiana; 62nd Conference on Magnetism and
+    Magnetic Materials (MMM 2017), November 6-10, 2017, Pittsburgh,
+    Pennsylvania; 21st International Conference on Magnetism (ICM
+    2018), July 16–20, 2018, San Francisco, California; 14th Joint
+    MMM-Intermag Conference (MMM2019), January 14-18, 2019,
+    Washington, DC). Each of those meetings is one week long, and
+    serves as a focal point of networking for the european and
+    international research community. Other training events have been
+    held in the past at these conferences and were well attended.} to
+  disseminate the micromagnetic virtual research environment
+  (Sect. \ref{sec:introduction-micromagnetic-vre-demonstrator} and
+  \localtaskref{dissemination-of-oommf-nb-virtual-environment}) in the
+  micromagnetic community. Each conference attracts around 1500
+  participants, and we expect at least 30 for our workshops at every
+  event. Depending on demand, multiple workshops will be given per
+  conference.
 
-The taught material will include (i) use of the \Jupyter-based
-micromagnetic VRE, and an (ii) introduction to the standard techniques
-for contributing to open source software (version control, pull
-requests, testing frameworks) to foster excellence in computational
-science and to make the micromagnetic VRE project self-sustaining as quickly
-as possible. In addition, all teaching materials, including videos,
-will be made available on a website.
+  The taught material will include (i) use of the \Jupyter-based
+  micromagnetic VRE, and an (ii) introduction to the standard
+  techniques for contributing to open source software (version
+  control, pull requests, testing frameworks) to foster excellence in
+  computational science and to make the micromagnetic VRE project
+  self-sustaining as quickly as possible. In addition, all teaching
+  materials, including videos, will be made available on a website.
 
-For each workshop, we request \euro{500} room hire at the magnetism conference
-location and the travel expenses for two teachers from Southampton to
-attend the one week international conference, totalling (\euro{500} +
-2x\euro{2200}=\euro{4900}) per workshop. There are no other costs.
+  For each workshop, we request \euro{500} room hire at the magnetism
+  conference location and the travel expenses for two teachers from
+  Southampton to attend the one week international conference,
+  totalling (\euro{500} + 2x\euro{2200}=\euro{4900}) per
+  workshop. There are no other costs.
 
-We will use the micromagnetic VRE demonstrator
-(\taskref{UI}{oommf-tutorial-and-documentation}), its dissemination
-workshops \linebreak(\taskref{dissem}{dissemination-of-oommf-nb-workshops})
-and interactions with its users and contributors in the
-micromagnetic community to evaluate, reflect and report on the project,
-taking into account technical and social aspects.
+  We will use the micromagnetic VRE demonstrator
+  (\taskref{UI}{oommf-tutorial-and-documentation}), its dissemination
+  workshops
+  \linebreak(\taskref{dissem}{dissemination-of-oommf-nb-workshops})
+  and interactions with its users and contributors in the
+  micromagnetic community to evaluate, reflect and report on the
+  project, taking into account technical and social aspects.
 
-A survey will be developed and used to gather user input and
-feedback on usefulness of the provided capabilities, with particular
-focus on the capabilities of the micromagnetic VRE to (i) enable new
-and better science, to (ii) allow to make progress effectively, to
-(iii) carry out computational science reproducibly, to (iv)
-collaboratively enable trust and to (v) become a self-sustained
-project from community contributions. Amongst other channels, we
-will target attendees of the micromagnetic VRE dissemination
-workshops (\taskref{dissem}{dissemination-of-oommf-nb-workshops}) to
-gather data.
+  A survey will be developed and used to gather user input and
+  feedback on usefulness of the provided capabilities, with particular
+  focus on the capabilities of the micromagnetic VRE to (i) enable new
+  and better science, to (ii) allow to make progress effectively, to
+  (iii) carry out computational science reproducibly, to (iv)
+  collaboratively enable trust and to (v) become a self-sustained
+  project from community contributions. Amongst other channels, we
+  will target attendees of the micromagnetic VRE dissemination
+  workshops (\taskref{dissem}{dissemination-of-oommf-nb-workshops}) to
+  gather data.
 
-All results and insights will be summarised in a public document
-(\localdelivref{oommf-nb-evaluation}) and reported at appropriate
-workshops and conferences to share the lessons learned from this
-\Jupyter-based VRE for micromagnetics. We will create a manuscript
-for journal publication, summarising the demonstrator project and
-this evaluation. An important point of this publication is to
-provide a reference that can be cited by publications making use of
-the new micromagnetic VRE, to allow tracking of uptake and
-development of this VRE beyond the life time of this H2020 project.
+  All results and insights will be summarised in a public document
+  (\localdelivref{oommf-nb-evaluation}) and reported at appropriate
+  workshops and conferences to share the lessons learned from this
+  \Jupyter-based VRE for micromagnetics. We will create a manuscript
+  for journal publication, summarising the demonstrator project and
+  this evaluation. An important point of this publication is to
+  provide a reference that can be cited by publications making use of
+  the new micromagnetic VRE, to allow tracking of uptake and
+  development of this VRE beyond the life time of this H2020 project.
 \end{task}
 
 \begin{task}[title=Demonstrator: Interactive books,

--- a/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
+++ b/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
@@ -322,7 +322,7 @@ Yearly reports on the impact of these workshops on the community (\delivref{diss
 \end{task}
 
 \begin{task}[title=Micromagnetic VRE dissemination workshops,
-id=dissemination-of-oommf-nb-workshops,lead=XFEL,PM=6,partners={USO},wphases=18-44!0.23,issue=31] % funny ratio here, that's okay (HF)
+id=dissemination-of-oommf-nb-workshops,lead=XFEL,PM=6,partners={USO},wphases=18-44!0.46,issue=31] % funny ratio here, that's okay (HF, MB)
 
   % 3 months person time, 2 months investigator time
 

--- a/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
+++ b/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
@@ -342,7 +342,7 @@ id=dissemination-of-oommf-nb-workshops,lead=XFEL,PM=6,partners={USO},wphases=18-
     international research community. Other training events have been
     held in the past at these conferences and were well attended.} to
   disseminate the micromagnetic virtual research environment
-  (Sect. \ref{sec:introduction-micromagnetic-vre-demonstrator} and
+  (Sect.~\ref{sec:introduction-micromagnetic-vre-demonstrator} and
   \localtaskref{dissemination-of-oommf-nb-virtual-environment}) in the
   micromagnetic community. Each conference attracts around 1500
   participants, and we expect at least 30 for our workshops at every
@@ -365,32 +365,30 @@ id=dissemination-of-oommf-nb-workshops,lead=XFEL,PM=6,partners={USO},wphases=18-
 
   We will use the micromagnetic VRE demonstrator
   (\taskref{UI}{oommf-tutorial-and-documentation}), its dissemination
-  workshops
-  \linebreak(\taskref{dissem}{dissemination-of-oommf-nb-workshops})
+  workshops (\taskref{dissem}{dissemination-of-oommf-nb-workshops})
   and interactions with its users and contributors in the
   micromagnetic community to evaluate, reflect and report on the
-  project, taking into account technical and social aspects.
-
-  A survey will be developed and used to gather user input and
-  feedback on usefulness of the provided capabilities, with particular
-  focus on the capabilities of the micromagnetic VRE to (i) enable new
-  and better science, to (ii) allow to make progress effectively, to
-  (iii) carry out computational science reproducibly, to (iv)
+  project, taking into account technical and social aspects. A survey
+  will be developed and used to gather user input and feedback on
+  usefulness of the provided capabilities, with particular focus on
+  the capabilities of the micromagnetic VRE to (i) enable new and
+  better science, to (ii) allow to make progress effectively, to (iii)
+  carry out computational science reproducibly, to (iv)
   collaboratively enable trust and to (v) become a self-sustained
   project from community contributions. Amongst other channels, we
   will target attendees of the micromagnetic VRE dissemination
   workshops (\taskref{dissem}{dissemination-of-oommf-nb-workshops}) to
   gather data.
 
-  All results and insights will be summarised in a public document
-  (\localdelivref{oommf-nb-evaluation}) and reported at appropriate
-  workshops and conferences to share the lessons learned from this
-  \Jupyter-based VRE for micromagnetics. We will create a manuscript
-  for journal publication, summarising the demonstrator project and
-  this evaluation. An important point of this publication is to
-  provide a reference that can be cited by publications making use of
-  the new micromagnetic VRE, to allow tracking of uptake and
-  development of this VRE beyond the life time of this H2020 project.
+  All results and insights will be summarised in a public document and
+  reported at appropriate workshops and conferences to share the
+  lessons learned from this \Jupyter-based VRE for micromagnetics. We
+  will create a manuscript for journal publication, summarising the
+  demonstrator project and this evaluation. An important point of this
+  publication is to provide a reference that can be cited by
+  publications making use of the new micromagnetic VRE, to allow
+  tracking of uptake and development of this VRE beyond the life time
+  of this H2020 project.
 \end{task}
 
 \begin{task}[title=Demonstrator: Interactive books,

--- a/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
+++ b/Proposal/WorkPackages/DisseminationCommunityBuilding.tex
@@ -359,6 +359,34 @@ For each workshop, we request \euro{500} room hire at the magnetism conference
 location and the travel expenses for two teachers from Southampton to
 attend the one week international conference, totalling (\euro{500} +
 2x\euro{2200}=\euro{4900}) per workshop. There are no other costs.
+
+We will use the micromagnetic VRE demonstrator
+(\taskref{UI}{oommf-tutorial-and-documentation}), its dissemination
+workshops \linebreak(\taskref{dissem}{dissemination-of-oommf-nb-workshops})
+and interactions with its users and contributors in the
+micromagnetic community to evaluate, reflect and report on the project,
+taking into account technical and social aspects.
+
+A survey will be developed and used to gather user input and
+feedback on usefulness of the provided capabilities, with particular
+focus on the capabilities of the micromagnetic VRE to (i) enable new
+and better science, to (ii) allow to make progress effectively, to
+(iii) carry out computational science reproducibly, to (iv)
+collaboratively enable trust and to (v) become a self-sustained
+project from community contributions. Amongst other channels, we
+will target attendees of the micromagnetic VRE dissemination
+workshops (\taskref{dissem}{dissemination-of-oommf-nb-workshops}) to
+gather data.
+
+All results and insights will be summarised in a public document
+(\localdelivref{oommf-nb-evaluation}) and reported at appropriate
+workshops and conferences to share the lessons learned from this
+\Jupyter-based VRE for micromagnetics. We will create a manuscript
+for journal publication, summarising the demonstrator project and
+this evaluation. An important point of this publication is to
+provide a reference that can be cited by publications making use of
+the new micromagnetic VRE, to allow tracking of uptake and
+development of this VRE beyond the life time of this H2020 project.
 \end{task}
 
 \begin{task}[title=Demonstrator: Interactive books,

--- a/Proposal/WorkPackages/SocialAspects.tex
+++ b/Proposal/WorkPackages/SocialAspects.tex
@@ -229,7 +229,7 @@ and reported at relevant AI workshops and conferences.
 \end{task}
 
 \begin{task}[title=Evaluation of Micromagnetic VRE,lead=XFEL,PM=6,
-id=oommf-nb-evaluation,partners={UO,PS},wphases=32-44!0.5,issue=147]
+id=oommf-nb-evaluation,partners={UO,PS},wphases=32-44!0,issue=147]
   % 4 person months, 1 person month investigator time
   We will use the micromagnetic VRE demonstrator
   (\taskref{UI}{oommf-tutorial-and-documentation}), its dissemination

--- a/Proposal/WorkPackages/SocialAspects.tex
+++ b/Proposal/WorkPackages/SocialAspects.tex
@@ -228,11 +228,14 @@ The results of this task will be summarised in \localdelivref{social-gametheoret
 and reported at relevant AI workshops and conferences.
 \end{task}
 
-\begin{task}[title=Evaluation of Micromagnetic VRE,lead=XFEL,PM=6,
-id=oommf-nb-evaluation,partners={UO,PS},wphases=32-44!0,issue=147]
+%
+% This task is now moved to T2.8 (MB)
+%
+%\begin{task}[title=Evaluation of Micromagnetic VRE,lead=XFEL,PM=6,
+%id=oommf-nb-evaluation,partners={UO,PS},wphases=32-44!0,issue=147]
   % 4 person months, 1 person month investigator time
- Now moved to T.28.
-\end{task}
+% Now moved to T.28.
+%\end{task}
 
 
 

--- a/Proposal/WorkPackages/SocialAspects.tex
+++ b/Proposal/WorkPackages/SocialAspects.tex
@@ -14,7 +14,7 @@
 \begin{workpackage}[id=social-aspects,wphases=0-48,
   title=Social Aspects,
   lead=UO,
-  UORM=23,USHRM=24,XFELRM=6]
+  UORM=23,USHRM=24]
 
 \begin{wpobjectives}
 

--- a/Proposal/WorkPackages/SocialAspects.tex
+++ b/Proposal/WorkPackages/SocialAspects.tex
@@ -275,9 +275,9 @@ and reported at relevant AI workshops and conferences.
 {Game-theoretic analysis of development practices in open-source VREs}
 \end{wpdeliv}
 
- \begin{wpdeliv}[due=48,miles=eval,id=oommf-nb-evaluation,dissem=PU,nature=R,lead=XFEL,issue=155]
-      {Micromagnetic VRE environment evaluation report}
-\end{wpdeliv}
+%\begin{wpdeliv}[due=48,miles=eval,id=oommf-nb-evaluation,dissem=PU,nature=R,lead=XFEL,issue=155]
+%     {Micromagnetic VRE environment evaluation report}
+%\end{wpdeliv}
 \end{wpdelivs}
 \end{workpackage}
 %%% Local Variables:

--- a/Proposal/WorkPackages/SocialAspects.tex
+++ b/Proposal/WorkPackages/SocialAspects.tex
@@ -231,33 +231,7 @@ and reported at relevant AI workshops and conferences.
 \begin{task}[title=Evaluation of Micromagnetic VRE,lead=XFEL,PM=6,
 id=oommf-nb-evaluation,partners={UO,PS},wphases=32-44!0,issue=147]
   % 4 person months, 1 person month investigator time
-  We will use the micromagnetic VRE demonstrator
-  (\taskref{UI}{oommf-tutorial-and-documentation}), its dissemination
-  workshops \linebreak(\taskref{dissem}{dissemination-of-oommf-nb-workshops})
-  and interactions with its users and contributors in the
-  micromagnetic community to evaluate, reflect and report on the project,
-  taking into account technical and social aspects.
-
-  A survey will be developed and used to gather user input and
-  feedback on usefulness of the provided capabilities, with particular
-  focus on the capabilities of the micromagnetic VRE to (i) enable new
-  and better science, to (ii) allow to make progress effectively, to
-  (iii) carry out computational science reproducibly, to (iv)
-  collaboratively enable trust and to (v) become a self-sustained
-  project from community contributions. Amongst other channels, we
-  will target attendees of the micromagnetic VRE dissemination
-  workshops (\taskref{dissem}{dissemination-of-oommf-nb-workshops}) to
-  gather data.
-
-  All results and insights will be summarised in a public document
-  (\localdelivref{oommf-nb-evaluation}) and reported at appropriate
-  workshops and conferences to share the lessons learned from this
-  \Jupyter-based VRE for micromagnetics. We will create a manuscript
-  for journal publication, summarising the demonstrator project and
-  this evaluation. An important point of this publication is to
-  provide a reference that can be cited by publications making use of
-  the new micromagnetic VRE, to allow tracking of uptake and
-  development of this VRE beyond the life time of this H2020 project.
+ Now moved to T.28.
 \end{task}
 
 

--- a/Proposal/demonstrators.tex
+++ b/Proposal/demonstrators.tex
@@ -50,11 +50,10 @@ simulation software (Object Oriented MicroMagnetic Framework
 components that add value, including notebook user interfaces,
 replacing the current text driven, unautomated and error-prone workflow.
 
-We will evaluate this demonstrator application in 
-\taskref{social-aspects}{oommf-nb-evaluation}, immediately feeding
-results back into the \TheProject work. This will also
-be a case study for the sustainability of the approach and tool beyond
-the life time of this H2020 project.
+We will evaluate this demonstrator application, immediately feeding
+results back into the \TheProject work. This will also be a case study
+for the sustainability of the approach and tool beyond the life time
+of this H2020 project.
 
 \paragraph{Demonstrator: Computational Mathematics Resource Indexing
 Service}

--- a/Proposal/grantagreement-history.tex
+++ b/Proposal/grantagreement-history.tex
@@ -203,6 +203,26 @@ instructions (e.g. AVX, etc.), especially in the FFT butterflies"
 \end{enumerate}
 
 \end{enumerate}
+
+\clearpage
+\thispagestyle{empty}
+\subsection*{3rd amendment of the Grant Agreement, July 2017}
+\ednote{insert month when ready}
+\begin{enumerate}
+\item As suggested by the project officer and reviewers, reduction of
+  the number of deliverables:
+  \begin{itemize}
+  \item Merged together D7.8 and D2.13, lead by \site{XFEL}. Merged
+    deliverable is now D2.13.
+  \end{itemize}
+\item As suggested by the project officer and reviewers, removal of the WP7:
+  \begin{itemize}
+  \item Merged together T7.4 and T2.8, lead by \site{XFEL}. Merged
+    task is now T2.8.
+  \end{itemize}
+\end{enumerate}
+
+
 \clearpage
 \setcounter{page}{1}
 

--- a/Proposal/grantagreement-history.tex
+++ b/Proposal/grantagreement-history.tex
@@ -153,8 +153,11 @@ of Person-Month to be used by this site (within the frame of the 360,00.00€ of
   completed after month 24 and the deliverable \delivref{dissem}{oommfnb-vre-deliver} from
   \site{USO} to \site{XFEL}.
 \item \WPref{UI}: moved 5 PM from \site{USO} to \site{XFEL}.
-\item \WPref{social-aspects}: moved deliverable
-  \delivref{social-aspects}{oommf-nb-evaluation} and 6 PM from \site{USO} to \site{XFEL}.
+\item \WPref{social-aspects}: moved deliverable D7.8 and 6 PM from
+  \site{USO} to \site{XFEL}. % D7.8 is explicitly written here because
+                             % it is removed in the next proposal
+                             % change and we cannot refer to it
+                             % anymore (MB).
 
 \item Resources (Section~\ref{sec:resources}): moved the respective resources from
   \site{USO} to \site{XFEL}.

--- a/Proposal/grantagreement-history.tex
+++ b/Proposal/grantagreement-history.tex
@@ -215,13 +215,17 @@ instructions (e.g. AVX, etc.), especially in the FFT butterflies"
 \item As suggested by the project officer and reviewers, reduction of
   the number of deliverables:
   \begin{itemize}
-  \item Merged together D7.8 and D2.13, lead by \site{XFEL}. Merged
-    deliverable is now D2.13.
+  \item Merged together D7.8 and
+    \delivref{dissem}{oommfnb-vre-deliver}, lead by
+    \site{XFEL}. Merged deliverable is now
+    \delivref{dissem}{oommfnb-vre-deliver}.
   \end{itemize}
 \item As suggested by the project officer and reviewers, removal of the WP7:
   \begin{itemize}
-  \item Merged together T7.4 and T2.8, lead by \site{XFEL}. Merged
-    task is now T2.8.
+  \item Merged together T7.4 and
+    \taskref{dissem}{dissemination-of-oommf-nb-workshops}, lead by
+    \site{XFEL}. Merged task is now
+    \taskref{dissem}{dissemination-of-oommf-nb-workshops}.
   \end{itemize}
 \end{enumerate}
 

--- a/Proposal/grantagreement-history.tex
+++ b/Proposal/grantagreement-history.tex
@@ -112,7 +112,7 @@
 \ednote{insert month when ready}
 \begin{enumerate}
 \item Accomodate the move of the KWARC Group (Prof Michael Kohlhase) from \site{JU} to
-  \site{FAU}. 
+  \site{FAU}.
 \begin{enumerate}
 \item Addition of Friedrich Alexander University Erlangen/Nuremberg (\site{FAU}) to the
   list of beneficiaries.
@@ -121,17 +121,17 @@
   for the initial phase), moved 34 PM and the lead of all deliverables after month 15 from
   \site{JU} to \site{FAU}.
 \item \WPref{UI}: moved 8 PM and the lead of all deliverables after month 15 from
-  \site{JU} to \site{FAU}. 
+  \site{JU} to \site{FAU}.
 \item Resources (Section~\ref{sec:resources}): moved the respective resources from
   \site{JU} to \site{FAU}.
 \end{enumerate}
 \item \WPref{dksbases}: adapted the titles of \delivref{dksbases}{psfoundation},
   \delivref{dksbases}{pssem}, and \delivref{dksbases}{lfmverif} to respect the change in
   priority on system interoperability and distributed computing in the
-  ``Math-in-the-Middle'' Paradigm over algorithm verification. 
+  ``Math-in-the-Middle'' Paradigm over algorithm verification.
 \item Changed the lead of \delivref{component-architecture}{semantic-interface-sage-gap}
   from \site{UO} to \site{PS}, and the lead of \delivref{dksbases}{lfmverif} from \site{ZH} to \site{FAU}
-\item Changed the lead of \site{USH} from Neil Lawrence to Michael Croucher, and the breakdown 
+\item Changed the lead of \site{USH} from Neil Lawrence to Michael Croucher, and the breakdown
 of Person-Month to be used by this site (within the frame of the 360,00.00€ of their Personnel Costs)
 \item Typo fix: \delivref{UI}{ipython-kernels} was meant to be due M24, not M14.
 \item Changed the lead PI of \site{UO} from Ursula Martin to Dmitrii Pasechnik
@@ -211,18 +211,18 @@ instructions (e.g. AVX, etc.), especially in the FFT butterflies"
 \thispagestyle{empty}
 \subsection*{3rd amendment of the Grant Agreement, July 2017}
 \ednote{insert month when ready}
+Following feedback from project officer and reviewers at 18 month project review:
 \begin{enumerate}
-\item As suggested by the project officer and reviewers, reduction of
-  the number of deliverables:
+\item Reduction of number of deliverables:
   \begin{itemize}
   \item Merged together D7.8 and
     \delivref{dissem}{oommfnb-vre-deliver}, lead by
     \site{XFEL}. Merged deliverable is now
     \delivref{dissem}{oommfnb-vre-deliver}.
   \end{itemize}
-\item As suggested by the project officer and reviewers, removal of the WP7:
+\item Integration of WP7 activities into other WPs:
   \begin{itemize}
-  \item Merged together T7.4 and
+  \item Integrated T7.4 in
     \taskref{dissem}{dissemination-of-oommf-nb-workshops}, lead by
     \site{XFEL}. Merged task is now
     \taskref{dissem}{dissemination-of-oommf-nb-workshops}.

--- a/Proposal/workplan.tex
+++ b/Proposal/workplan.tex
@@ -164,7 +164,7 @@ will be embedded into the structures we leave behind.
 
 Objective 6 is covered by a dedicated work package \WPref{social-aspects} on social aspects.
 It ranges from analysis of the needs with~\taskref{social-aspects}{social-input} to
-evaluation with~\taskref{social-aspects}{oommf-nb-evaluation}.
+evaluation with~\taskref{social-aspects}{isocial-decisionmaking}.
 
 \paragraph{Work Programme for Objective 7: }
 

--- a/Proposal/workplan.tex
+++ b/Proposal/workplan.tex
@@ -36,7 +36,7 @@ components, \WPref{dksbases} for databases and finally
 the usual management and dissemination work packages
 (\WPref{management}) and (\WPref{dissem}). The Gantt chart on
 Page~\pageref{fig:gantt} illustrates the timeline for the various
-tasks for these work packages%., including inter-task dependencies.
+tasks for these work packages.%, including inter-task dependencies.
 
 \ifgrantagreement\else
 %\makeatletter\wp@total@RM{management}\makeatother


### PR DESCRIPTION
- move all XFEL time from WP7 to WP2 (with the one task associated)
- merge deliverable from WP7 with the one in WP2 (to also reduce the number of deliverables)
- updated grant history to reflect this

@nthiery, @bpilorget - do you want to review and feedback / merge?

[Thanks @mb1a15 for putting this together.]