### PR TITLE
Consolidate WP4 deliverables

### DIFF
--- a/Proposal/WorkPackages/UserInterfaces.tex
+++ b/Proposal/WorkPackages/UserInterfaces.tex
@@ -566,7 +566,7 @@ use it on dedicated HPC installations.
   \begin{wpdeliv}[due=36,miles=proto1,id=pari-python-lib2,dissem=PU,nature=OTHER,lead=UB,issue=84]
 	  {Second version of the \Pari Python/Cython bindings}
   \end{wpdeliv}
-    \begin{wpdeliv}[id=jupyter-import,due=30,miles=proto1,nature=DEM,dissem=PU,lead=FAU,issue=85]
+    \begin{wpdeliv}[id=jupyter-import,due=42,miles=proto1,nature=DEM,dissem=PU,lead=FAU,issue=85]
       {Notebook Import into MathHub.info (interactive display)}
     \end{wpdeliv}
 

--- a/Proposal/WorkPackages/UserInterfaces.tex
+++ b/Proposal/WorkPackages/UserInterfaces.tex
@@ -234,8 +234,8 @@
   % In charge: \Jupyter dev + dev in Orsay + NT?
 \end{task}
 
-\begin{task}[title=Active and Structured documents,id=structdocs,
-  lead=JU,PM=34,partners={SR,USH,LL,FAU},wphases=0-36,issue=74]
+\begin{task}[title=Structured documents,id=structdocs,
+  lead=JU,PM=22,partners={SR,USH,LL,FAU},wphases=0-24,issue=74]
   \Jupyter notebooks consist of a sequence of cells that contain
   either text or a program (see Section~\ref{sec:jupyter}). Complex
   documents, such as books, articles or reports, require a richer
@@ -266,26 +266,28 @@
   Results of this convergence will be reported
   in~\localdelivref{adcomp}, \localdelivref{ipython-kernel-sage} and
   \localdelivref{jupyter-import} and used in \taskref{dissem}{ibook}.
+\end{task}
+
+\begin{task}[id=mathhub,title=Active Documents Portal,lead=FAU,PM=12,partners={JU},
+  wphases=12-36!.5,issue=75]
   We will extend the existing \url{http://mathhub.info} system to a
-  portal for interacting with these active/structured documents
-  and releasing the portal initially for
+  portal for interacting with active/structured documents (see
+  \localtaskref{structdocs}) and releasing the portal initially for
   internal use in the \TheProject and later for general
   use. \url{MathHub.info} already provides very basic sTeX editing and
   versioning. In \TheProject we will extend it on the computational
-  side based on the integrated format.
-  The resulting portal will be made
+  side based on the integrated format from
+  \localtaskref{structdocs}. The resulting portal will be made
   available to the consortium as~\localdelivref{mathhub-editing} and
   would be used for semantically enhanced code documentation and
   knowledge representation (see \WPref{dksbases}).
 \end{task}
 
-\begin{task}[id=mathhub,title=Active Documents Portal,
-  issue=75]
-  This task has been merged into \localtaskref{structdocs}.
-\end{task}
-
 \begin{task}[title=Visualisation system for 3D data in web-notebook
-,id=vis3d,lead=SR, partners={US,PS,USO}, PM=18, wphases=0-48, issue=76]
+,id=vis3d,lead=SR, partners={US,PS,USO}, PM=13, wphases=0-24, issue=76]
+\TOWRITE{MRK,HPL}{wphases does not agree with PM. (13 vs 24}
+%12 months from Simular,
+% 1 month from Southampton for testing in the micromagnetic VRE demonstrator
 
 The \Jupyter notebook provides an attractive environment for building
 user interfaces for research. However, the current support for inline
@@ -332,6 +334,11 @@ The \href{http://www.math.uic.edu/t3m/SnapPy/}{SnapPy} and
 \href{http://sagemanifolds.obspm.fr/}{SageManifolds} projects will be
 considered for deployment of tools we develop (see associated
 deliverable \localdelivref{vis3d}).
+\end{task}
+
+
+\begin{task}[title=Visualisation of 3D fluid dynamics data in web-notebook
+,id=cfd-vis,lead=SR, partners={US,PS,USO,XFEL},PM=5,wphases=12-36,issue=77]
 
 We propose to let computational fluid dynamics (CFD) be a driving
 application for the development of 3D visualisation in \Jupyter
@@ -376,16 +383,11 @@ use it on dedicated HPC installations.
   In this task, we will provide a uniform option system for displaying
   an object within \Sage (raw text, \LaTeX, tikz, matplotlib, jmol,
   tachyon, \ldots). We will implement some of the missing display and
-  will benefit of the work done in \localtaskref{vis3d}.
+  will benefit of the work done in \taskref{UI}{cfd-vis}.
 \end{task}
 
-\begin{task}[title=Visualisation of 3D fluid dynamics data in web-notebook,
-  id=cfd-vis,issue=77]
-  This task has been merged into \localtaskref{vis3d}.
-\end{task}
-
-\begin{task}[lead=XFEL,title=Case study: micromagnetic VRE built from
-  \TheProject,id=oommf-py-ipython-attributes,PM=15,partners={SR,USH,PS,USO,FAU},wphases=13-28,issue=79]
+\begin{task}[lead=USO,title=Case study: micromagnetic VRE built from
+  \TheProject,id=oommf-py-ipython-attributes,PM=6,partners={SR,USH},wphases=13-19,issue=79]
   % 6 person months
   In this task, we use the \TheProject architecture to assemble a
   virtual research environment software tailored for the large
@@ -425,56 +427,6 @@ use it on dedicated HPC installations.
   match GUI-based and command driven analysis combines the best of
   both approaches, caters for users' preferences, and provides
   significant additional value.
-
-  The purpose of the micromagnetic \VRE is to enable excellent
-  computational research. To maximise the value of this grant's
-  investment for the community, we will not carry out micromagnetic
-  research but instead produce a set of executable notebooks using the
-  micromagnetic \VRE to demonstrate its power and applicability.
-
-  We will create executable notebook documents
-  within the micromagnetic \VRE
-  including (i) a new tutorial on computational micromagnetics with
-  OOMMF, (ii) the complete documentation of the \texttt{OOMMF-Py}
-  library (\taskref{component-architecture}{oommf-python-interface}),
-  and (iii) a set of typical micromagnetic case studies. The tutorial,
-  in terms of content, will take guidance from the tutorial provided
-  for Nmag \cite{Nmag-tutorial-url} and will introduce the additional
-  features of the \Jupyter-driven micromagnetic \VRE. We expect this
-  substantial and executable documentation of the micromagnetic \VRE to
-  become the standard resource that introduces researchers to
-  computational micromagnetics, in particular through the online
-  portal.
-
-  Recently, a TeMPorary \Jupyter NoteBook (TMPNB) has been made
-  available (at \href{http://tmpnb.org}{http://tmpnb.org}) that allows
-  anybody to open this URL and use their very own \Jupyter notebook
-  for quick calculations and tests online. We will provide such a
-  portal which provides the
-  micromagnetic \VRE for anonymous use. This service allows users to
-  execute the demonstrator tutorial and documentation notebooks
-  and run the
-  calculations in real time on the web server, without having to
-  install any software on their own machine.  This web service will be
-  based on Docker \cite{Docker} virtualisation technology and we will
-  make available the scripts to create VirtualBox \cite{Virtualbox}
-  images, and Docker containers. The same virtual machine images can
-  also be used for Cloud hosted computing services.
-
-  %{HF}{Do we need the resource request here? Or should it
-  %just be in resources.tex: Either works, in the resources file there
-  %is only the total sum mentioned and a link to here. So no
-  %duplication of information, and the particular machine is maybe
-  %better explained here. I'll comment this out to 'resolve' it.}
-
-  We request \euro{6000} to purchase a machine to provide these
-  services (shared memory, 64 cores, 128GB RAM, Solid-state drive (SDD)
-  to make the system more responsive).
-  %This machine will also support
-  %the regression testing and continuous integration (see task
-  %\taskref{dissem}{dissemination-of-oommf-nb-virtual-environment}).
-  %Setup and
-  %maintenance of the machine is part of this work task.
 \end{task}
 
 \begin{task}[lead=UB,title=Python/Cython bindings for \Pari,PM=16,id=pari-python,partners={UB,UG},wphases=0-48,issue=80]
@@ -501,9 +453,29 @@ use it on dedicated HPC installations.
   require expertise of some \Sage, \Pari or \Cython developers (Jeroen Demeyer, Peter Bruin).
 \end{task}
 
-\begin{task}[title=Demonstrator: micromagnetic VRE notebooks,
-  id=oommf-tutorial-and-documentation,issue=81]
-  This task has been merged into \localtaskref{oommf-py-ipython-attributes}.
+\begin{task}[lead=XFEL,title=Demonstrator: micromagnetic VRE notebooks,
+  id=oommf-tutorial-and-documentation,PM=6,partners={SR,PS,USO},wphases=19-25,issue=81]
+  % 5 person months + 1 month co-investigator [Ian Hawke's experience]
+  The purpose of the micromagnetic \VRE
+  (\localtaskref{oommf-py-ipython-attributes}) is to enable excellent
+  computational research. To maximise the value of this grant's
+  investment for the community, we will not carry out micromagnetic
+  research but instead produce a set of executable notebooks using the
+  micromagnetic \VRE to demonstrate its power and applicability.
+
+  We will create executable notebook documents
+  within the micromagnetic \VRE
+  including (i) a new tutorial on computational micromagnetics with
+  OOMMF, (ii) the complete documentation of the \texttt{OOMMF-Py}
+  library (\taskref{component-architecture}{oommf-python-interface}),
+  and (iii) a set of typical micromagnetic case studies. The tutorial,
+  in terms of content, will take guidance from the tutorial provided
+  for Nmag \cite{Nmag-tutorial-url} and will introduce the additional
+  features of the \Jupyter-driven micromagnetic \VRE. We expect this
+  substantial and executable documentation of the micromagnetic \VRE to
+  become the standard resource that introduces researchers to
+  computational micromagnetics, in particular through the online
+  portal (\localtaskref{oommf-nb-ve}).
 
   %% This block is about the benefits of using the notebook. It should
   %% go somewhere else in more generic form:
@@ -526,9 +498,38 @@ use it on dedicated HPC installations.
   %using the tool and environment.
 \end{task}
 
-\begin{task}[id=oommf-nb-ve,title=Online portal for
-  micromagnetic VRE demonstrator,issue=82]
-  This task has been merged into \localtaskref{oommf-py-ipython-attributes}.
+\begin{task}[lead=XFEL,id=oommf-nb-ve,title=Online portal for
+  micromagnetic VRE demonstrator,PM=3,partners={SR,FAU},wphases=25-28,issue=82]
+  % 3 person months
+  Recently, a TeMPorary \Jupyter NoteBook (TMPNB) has been made
+  available (at \href{http://tmpnb.org}{http://tmpnb.org}) that allows
+  anybody to open this URL and use their very own \Jupyter notebook
+  for quick calculations and tests online. We will provide such a
+  portal which provides the
+  micromagnetic \VRE for anonymous use. This service allows users to
+  execute the demonstrator tutorial and documentation notebooks
+  (\localtaskref{oommf-tutorial-and-documentation}) and run the
+  calculations in real time on the web server, without having to
+  install any software on their own machine.  This web service will be
+  based on Docker \cite{Docker} virtualisation technology and we will
+  make available the scripts to create VirtualBox \cite{Virtualbox}
+  images, and Docker containers. The same virtual machine images can
+  also be used for Cloud hosted computing services.
+
+  %{HF}{Do we need the resource request here? Or should it
+  %just be in resources.tex: Either works, in the resources file there
+  %is only the total sum mentioned and a link to here. So no
+  %duplication of information, and the particular machine is maybe
+  %better explained here. I'll comment this out to 'resolve' it.}
+
+  We request \euro{6000} to purchase a machine to provide these
+  services (shared memory, 64 cores, 128GB RAM, Solid-state drive (SDD)
+  to make the system more responsive).
+  %This machine will also support
+  %the regression testing and continuous integration (see task
+  %\taskref{dissem}{dissemination-of-oommf-nb-virtual-environment}).
+  %Setup and
+  %maintenance of the machine is part of this work task.
 \end{task}
 
 \end{tasklist}

--- a/Proposal/WorkPackages/UserInterfaces.tex
+++ b/Proposal/WorkPackages/UserInterfaces.tex
@@ -565,18 +565,18 @@ use it on dedicated HPC installations.
   \begin{wpdeliv}[due=36,miles=proto1,id=pari-python-lib2,dissem=PU,nature=OTHER,lead=UB,issue=84]
 	  {Second version of the \Pari Python/Cython bindings}
   \end{wpdeliv}
-    \begin{wpdeliv}[id=jupyter-import,due=24,miles=proto1,nature=DEM,dissem=PU,lead=FAU,issue=85]
+    \begin{wpdeliv}[id=jupyter-import,due=30,miles=proto1,nature=DEM,dissem=PU,lead=FAU,issue=85]
       {Notebook Import into MathHub.info (interactive display)}
     \end{wpdeliv}
 
-  \begin{wpdeliv}[due=24,id=vis3d,miles=proto1,dissem=PU,nature=OTHER,lead=SR,issue=86]
-      {\Jupyter extension for 3D visualisation}
+  \begin{wpdeliv}[due=36,id=vis3d,miles=community,dissem=PU,nature=OTHER,lead=SR,issue=86]
+      {\Jupyter extension for 3D visualisation, demonstrated with computational fluid dynamics}
   \end{wpdeliv}
   \begin{wpdeliv}[due=24,miles=proto1,id=sage-sphinx,dissem=PU,nature=OTHER,lead=UG,issue=87]
       {Refactorisation of \Sage's \Sphinx documentation system}
   \end{wpdeliv}
-  \begin{wpdeliv}[due=36,miles=community,id=cfd-vis,dissem=PU,nature=OTHER,lead=SR,issue=88]
-      {Computational Fluid dynamics visualisation in web notebook}
+  \begin{wpdeliv}[due=0,miles=community,id=cfd-vis,dissem=PU,nature=OTHER,lead=SR,issue=88]
+      {Merged with \localdelivref{vis3d}}
   \end{wpdeliv}
   \begin{wpdeliv}[due=36,miles=community,id=jupyter-live-collab,dissem=PU,nature=OTHER,lead=SR,issue=89]
       {Exploratory support for live notebook collaboration}

--- a/Proposal/WorkPackages/UserInterfaces.tex
+++ b/Proposal/WorkPackages/UserInterfaces.tex
@@ -114,7 +114,7 @@
 
 \end{task}
 
-\begin{task}[id=notebook-collab,title=Notebook improvements for collaboration,lead=SR, partners={PS,USH,JU,FAU,USO,LL}, PM=20, wphases=0-24, issue=70]
+\begin{task}[id=notebook-collab,title=Notebook improvements for collaboration,lead=SR, partners={PS,USH,JU,FAU,USO,LL}, PM=20, wphases=0-48, issue=70]
   In this task, we will further improve tools for collaboration
   between authors of shared \Jupyter notebooks and draw from the
   experience of collaboration as set in Simulagora, SageMathCloud,
@@ -150,6 +150,9 @@
   avenues for live session collaboration will be explored for
   integration into \Jupyter itself
   \localdelivref{jupyter-live-collab}.
+  
+  These tools will continue to be developed throughout the project
+  beyond the deliverable dates, as they are adopted by the community.
 \end{task}
 
 \begin{task}[id=notebook-verification,title=Reproducible Notebooks,lead=SR, partners={PS,USO}, PM=4, wphases=12-24, issue=71]
@@ -231,8 +234,8 @@
   % In charge: \Jupyter dev + dev in Orsay + NT?
 \end{task}
 
-\begin{task}[title=Structured documents,id=structdocs,
-  lead=JU,PM=22,partners={SR,USH,LL,FAU},wphases=0-24,issue=74]
+\begin{task}[title=Active and Structured documents,id=structdocs,
+  lead=JU,PM=34,partners={SR,USH,LL,FAU},wphases=0-36,issue=74]
   \Jupyter notebooks consist of a sequence of cells that contain
   either text or a program (see Section~\ref{sec:jupyter}). Complex
   documents, such as books, articles or reports, require a richer
@@ -263,28 +266,26 @@
   Results of this convergence will be reported
   in~\localdelivref{adcomp}, \localdelivref{ipython-kernel-sage} and
   \localdelivref{jupyter-import} and used in \taskref{dissem}{ibook}.
-\end{task}
-
-\begin{task}[id=mathhub,title=Active Documents Portal,lead=FAU,PM=12,partners={JU},
-  wphases=12-36!.5,issue=75]
   We will extend the existing \url{http://mathhub.info} system to a
-  portal for interacting with active/structured documents (see
-  \localtaskref{structdocs}) and releasing the portal initially for
+  portal for interacting with these active/structured documents
+  and releasing the portal initially for
   internal use in the \TheProject and later for general
   use. \url{MathHub.info} already provides very basic sTeX editing and
   versioning. In \TheProject we will extend it on the computational
-  side based on the integrated format from
-  \localtaskref{structdocs}. The resulting portal will be made
+  side based on the integrated format.
+  The resulting portal will be made
   available to the consortium as~\localdelivref{mathhub-editing} and
   would be used for semantically enhanced code documentation and
   knowledge representation (see \WPref{dksbases}).
 \end{task}
 
+\begin{task}[id=mathhub,title=Active Documents Portal,
+  issue=75]
+  This task has been merged into \localtaskref{structdocs}.
+\end{task}
+
 \begin{task}[title=Visualisation system for 3D data in web-notebook
-,id=vis3d,lead=SR, partners={US,PS,USO}, PM=13, wphases=0-24, issue=76]
-\TOWRITE{MRK,HPL}{wphases does not agree with PM. (13 vs 24}
-%12 months from Simular,
-% 1 month from Southampton for testing in the micromagnetic VRE demonstrator
+,id=vis3d,lead=SR, partners={US,PS,USO}, PM=18, wphases=0-48, issue=76]
 
 The \Jupyter notebook provides an attractive environment for building
 user interfaces for research. However, the current support for inline
@@ -331,11 +332,6 @@ The \href{http://www.math.uic.edu/t3m/SnapPy/}{SnapPy} and
 \href{http://sagemanifolds.obspm.fr/}{SageManifolds} projects will be
 considered for deployment of tools we develop (see associated
 deliverable \localdelivref{vis3d}).
-\end{task}
-
-
-\begin{task}[title=Visualisation of 3D fluid dynamics data in web-notebook
-,id=cfd-vis,lead=SR, partners={US,PS,USO,XFEL},PM=5,wphases=12-36,issue=77]
 
 We propose to let computational fluid dynamics (CFD) be a driving
 application for the development of 3D visualisation in \Jupyter
@@ -380,11 +376,16 @@ use it on dedicated HPC installations.
   In this task, we will provide a uniform option system for displaying
   an object within \Sage (raw text, \LaTeX, tikz, matplotlib, jmol,
   tachyon, \ldots). We will implement some of the missing display and
-  will benefit of the work done in \taskref{UI}{cfd-vis}.
+  will benefit of the work done in \localtaskref{vis3d}.
 \end{task}
 
-\begin{task}[lead=USO,title=Case study: micromagnetic VRE built from
-  \TheProject,id=oommf-py-ipython-attributes,PM=6,partners={SR,USH},wphases=13-19,issue=79]
+\begin{task}[title=Visualisation of 3D fluid dynamics data in web-notebook,
+  id=cfd-vis,issue=77]
+  This task has been merged into \localtaskref{vis3d}.
+\end{task}
+
+\begin{task}[lead=XFEL,title=Case study: micromagnetic VRE built from
+  \TheProject,id=oommf-py-ipython-attributes,PM=15,partners={SR,USH,PS,USO,FAU},wphases=13-28,issue=79]
   % 6 person months
   In this task, we use the \TheProject architecture to assemble a
   virtual research environment software tailored for the large
@@ -424,6 +425,56 @@ use it on dedicated HPC installations.
   match GUI-based and command driven analysis combines the best of
   both approaches, caters for users' preferences, and provides
   significant additional value.
+
+  The purpose of the micromagnetic \VRE is to enable excellent
+  computational research. To maximise the value of this grant's
+  investment for the community, we will not carry out micromagnetic
+  research but instead produce a set of executable notebooks using the
+  micromagnetic \VRE to demonstrate its power and applicability.
+
+  We will create executable notebook documents
+  within the micromagnetic \VRE
+  including (i) a new tutorial on computational micromagnetics with
+  OOMMF, (ii) the complete documentation of the \texttt{OOMMF-Py}
+  library (\taskref{component-architecture}{oommf-python-interface}),
+  and (iii) a set of typical micromagnetic case studies. The tutorial,
+  in terms of content, will take guidance from the tutorial provided
+  for Nmag \cite{Nmag-tutorial-url} and will introduce the additional
+  features of the \Jupyter-driven micromagnetic \VRE. We expect this
+  substantial and executable documentation of the micromagnetic \VRE to
+  become the standard resource that introduces researchers to
+  computational micromagnetics, in particular through the online
+  portal.
+
+  Recently, a TeMPorary \Jupyter NoteBook (TMPNB) has been made
+  available (at \href{http://tmpnb.org}{http://tmpnb.org}) that allows
+  anybody to open this URL and use their very own \Jupyter notebook
+  for quick calculations and tests online. We will provide such a
+  portal which provides the
+  micromagnetic \VRE for anonymous use. This service allows users to
+  execute the demonstrator tutorial and documentation notebooks
+  and run the
+  calculations in real time on the web server, without having to
+  install any software on their own machine.  This web service will be
+  based on Docker \cite{Docker} virtualisation technology and we will
+  make available the scripts to create VirtualBox \cite{Virtualbox}
+  images, and Docker containers. The same virtual machine images can
+  also be used for Cloud hosted computing services.
+
+  %{HF}{Do we need the resource request here? Or should it
+  %just be in resources.tex: Either works, in the resources file there
+  %is only the total sum mentioned and a link to here. So no
+  %duplication of information, and the particular machine is maybe
+  %better explained here. I'll comment this out to 'resolve' it.}
+
+  We request \euro{6000} to purchase a machine to provide these
+  services (shared memory, 64 cores, 128GB RAM, Solid-state drive (SDD)
+  to make the system more responsive).
+  %This machine will also support
+  %the regression testing and continuous integration (see task
+  %\taskref{dissem}{dissemination-of-oommf-nb-virtual-environment}).
+  %Setup and
+  %maintenance of the machine is part of this work task.
 \end{task}
 
 \begin{task}[lead=UB,title=Python/Cython bindings for \Pari,PM=16,id=pari-python,partners={UB,UG},wphases=0-48,issue=80]
@@ -450,29 +501,9 @@ use it on dedicated HPC installations.
   require expertise of some \Sage, \Pari or \Cython developers (Jeroen Demeyer, Peter Bruin).
 \end{task}
 
-\begin{task}[lead=XFEL,title=Demonstrator: micromagnetic VRE notebooks,
-  id=oommf-tutorial-and-documentation,PM=6,partners={SR,PS,USO},wphases=19-25,issue=81]
-  % 5 person months + 1 month co-investigator [Ian Hawke's experience]
-  The purpose of the micromagnetic \VRE
-  (\localtaskref{oommf-py-ipython-attributes}) is to enable excellent
-  computational research. To maximise the value of this grant's
-  investment for the community, we will not carry out micromagnetic
-  research but instead produce a set of executable notebooks using the
-  micromagnetic \VRE to demonstrate its power and applicability.
-
-  We will create executable notebook documents
-  within the micromagnetic \VRE
-  including (i) a new tutorial on computational micromagnetics with
-  OOMMF, (ii) the complete documentation of the \texttt{OOMMF-Py}
-  library (\taskref{component-architecture}{oommf-python-interface}),
-  and (iii) a set of typical micromagnetic case studies. The tutorial,
-  in terms of content, will take guidance from the tutorial provided
-  for Nmag \cite{Nmag-tutorial-url} and will introduce the additional
-  features of the \Jupyter-driven micromagnetic \VRE. We expect this
-  substantial and executable documentation of the micromagnetic \VRE to
-  become the standard resource that introduces researchers to
-  computational micromagnetics, in particular through the online
-  portal (\localtaskref{oommf-nb-ve}).
+\begin{task}[title=Demonstrator: micromagnetic VRE notebooks,
+  id=oommf-tutorial-and-documentation,issue=81]
+  This task has been merged into \localtaskref{oommf-py-ipython-attributes}.
 
   %% This block is about the benefits of using the notebook. It should
   %% go somewhere else in more generic form:
@@ -495,38 +526,9 @@ use it on dedicated HPC installations.
   %using the tool and environment.
 \end{task}
 
-\begin{task}[lead=XFEL,id=oommf-nb-ve,title=Online portal for
-  micromagnetic VRE demonstrator,PM=3,partners={SR,FAU},wphases=25-28,issue=82]
-  % 3 person months
-  Recently, a TeMPorary \Jupyter NoteBook (TMPNB) has been made
-  available (at \href{http://tmpnb.org}{http://tmpnb.org}) that allows
-  anybody to open this URL and use their very own \Jupyter notebook
-  for quick calculations and tests online. We will provide such a
-  portal which provides the
-  micromagnetic \VRE for anonymous use. This service allows users to
-  execute the demonstrator tutorial and documentation notebooks
-  (\localtaskref{oommf-tutorial-and-documentation}) and run the
-  calculations in real time on the web server, without having to
-  install any software on their own machine.  This web service will be
-  based on Docker \cite{Docker} virtualisation technology and we will
-  make available the scripts to create VirtualBox \cite{Virtualbox}
-  images, and Docker containers. The same virtual machine images can
-  also be used for Cloud hosted computing services.
-
-  %{HF}{Do we need the resource request here? Or should it
-  %just be in resources.tex: Either works, in the resources file there
-  %is only the total sum mentioned and a link to here. So no
-  %duplication of information, and the particular machine is maybe
-  %better explained here. I'll comment this out to 'resolve' it.}
-
-  We request \euro{6000} to purchase a machine to provide these
-  services (shared memory, 64 cores, 128GB RAM, Solid-state drive (SDD)
-  to make the system more responsive).
-  %This machine will also support
-  %the regression testing and continuous integration (see task
-  %\taskref{dissem}{dissemination-of-oommf-nb-virtual-environment}).
-  %Setup and
-  %maintenance of the machine is part of this work task.
+\begin{task}[id=oommf-nb-ve,title=Online portal for
+  micromagnetic VRE demonstrator,issue=82]
+  This task has been merged into \localtaskref{oommf-py-ipython-attributes}.
 \end{task}
 
 \end{tasklist}

--- a/Proposal/WorkPackages/UserInterfaces.tex
+++ b/Proposal/WorkPackages/UserInterfaces.tex
@@ -566,7 +566,7 @@ use it on dedicated HPC installations.
   \begin{wpdeliv}[due=36,miles=proto1,id=pari-python-lib2,dissem=PU,nature=OTHER,lead=UB,issue=84]
 	  {Second version of the \Pari Python/Cython bindings}
   \end{wpdeliv}
-    \begin{wpdeliv}[id=jupyter-import,due=42,miles=proto1,nature=DEM,dissem=PU,lead=FAU,issue=85]
+    \begin{wpdeliv}[id=jupyter-import,due=36,miles=proto1,nature=DEM,dissem=PU,lead=FAU,issue=85]
       {Notebook Import into MathHub.info (interactive display)}
     \end{wpdeliv}
 

--- a/Proposal/grantagreement-history.tex
+++ b/Proposal/grantagreement-history.tex
@@ -202,6 +202,20 @@ integer and polynomial arithmetic,and include assembly primitives for SIMD proce
 instructions (e.g. AVX, etc.), especially in the FFT butterflies"
 \end{enumerate}
 
+\item  Consolidation of \WPref{UI} deliverables
+
+Some deliverables in \WPref{UI} were consolidated and shifted.
+
+\begin{enumerate}
+\item \delivref{UI}{cfd-vis} is merged with \delivref{UI}{vis3d}, to be delivered in M36.
+    The work planned is unchanged, only the merging of the reports.
+\item \delivref{UI}{jupyter-import} moved from M24 to M36 to incorporate results
+    from workshop on live structured documents.
+\item \taskref{UI}{notebook-collab} expanded from M1-M24 to M1-M48 (the full duration of the grant)
+    to reflect the ongoing nature of the work. Activity, total work, and deliverables are unchanged.
+\end{enumerate}
+
+
 \end{enumerate}
 \clearpage
 \setcounter{page}{1}


### PR DESCRIPTION
<del>

- merge 3D vis tasks and deliverables into one of each
- merge active & structured docs tasks into one task
- merge micromagnetics into one task (there are no micromagnetics deliverables in WP4)

Participants and PMs should be entirely unchanged. When tasks are merged, the work phase is the union of the merged tasks and the PMs are the sum. The work proposed is entirely unchanged. The only goal is to reduce the number of discrete reports we have to write when the time comes.

</del>

Material and deliverable changes:

- merge 3D vis deliverables, so there will be no preliminary deliverable in M24, only the final one in M36.
- delay mathhub notebook import by six months until after the workshop we are scheduling for October.
- Expand notebook-collab task work phases to full grant duration (from 36 to 48) to reflect ongoing work beyond deliverables. PMs are unchanged, just spread out. Deliverables are unaffected.

I didn't see any consolidation that I could make in other WP4 deliverables at this point. I could have at the beginning, but most of what could be consolidated has already been delivered,
so there wouldn't be a benefit.

cc @kohlhase for active docs, @fangohr for micromagnetics, @nthiery.